### PR TITLE
Update RTSS Link

### DIFF
--- a/Refresh-Rate-and-RTSS.html
+++ b/Refresh-Rate-and-RTSS.html
@@ -96,9 +96,9 @@
           </ol>
           <p class="page" id="rtss-setup"><h2>RTSS Setup - Enable OSD (On-Screen Display)</h2>
           <ol>
-          <li><p>Download the latest RivaTuner Statistics Server(<strong>NOTE</strong>: Currently it is 7.3.4 Beta 7), link below:</p>
+          <li><p>Download the latest RivaTuner Statistics Server(<strong>NOTE</strong>: Currently it is 7.3.4 Beta 8), link below:</p>
           </li>
-          <li><p><a href="https://download-eu2.guru3d.com/rtss/%5BGuru3D.com%5D-RTSSSetup734Beta7Build27504.rar">https://download-eu2.guru3d.com/rtss/%5BGuru3D.com%5D-RTSSSetup734Beta7Build27504.rar</a> </p>
+          <li><p><a href="https://forums.guru3d.com/threads/msi-ab-rtss-development-news-thread.412822/page-194#post-6103843">https://forums.guru3d.com/threads/msi-ab-rtss-development-news-thread.412822/page-194#post-6103843</a> </p>
           </li>
           <li><p>(If issues downloading, <strong>Right-Click &gt; Copy Link &gt; Paste it into Address Bar</strong>)</p>
           </li>


### PR DESCRIPTION
Directly link to the most recent forum post - allowing easier access to future versions of the previous is removed (for example, the original beta 7 link is now invalid).